### PR TITLE
Fix compilation on Linux Centos 6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,8 @@ if(WIN32)
 		add_definitions(-D NOMINMAX) # prevent windef.h min/max macros from interfering with stl's
 		#set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /EHsc")
     endif(MSVC)
+else()
+add_definitions(-fPIC)
 endif (WIN32)
 
 #specify app sources
@@ -69,7 +71,11 @@ endif(WIN32)
 add_library(${RENDER_LIB} STATIC ${RENDERLIB_SOURCES})
 target_link_libraries( ${RENDER_LIB} ${CORE_LIB})
 
+if(WIN32)
 set_target_properties( ${RENDER_LIB} PROPERTIES PREFIX "" )
+else()
+set_target_properties( ${RENDER_LIB} PROPERTIES PREFIX "lib" )
+endif()
 set_target_properties( ${RENDER_LIB} PROPERTIES OUTPUT_NAME ${RENDER_LIB} )
 set_target_properties( ${RENDER_LIB} PROPERTIES LINKER_LANGUAGE CXX )
 set_target_properties( ${RENDER_LIB} PROPERTIES ARCHIVE_OUTPUT_DIRECTORY ${RENDERLIB_OUTPUT_FOLDER} )

--- a/source/dataStructs/bvh/bvh.cpp
+++ b/source/dataStructs/bvh/bvh.cpp
@@ -81,8 +81,8 @@ void BVH::split( size_t nodeIndex,
         int longestAxis = bounds.longestAxis();
 #ifdef _DEBUG
         float longestAxisLength = bounds.extents()[longestAxis];
-#endif
         assert(longestAxisLength > 0);
+#endif
         // classify primitives with regards of the spatial mean
 
         float cMin = FLT_MAX;


### PR DESCRIPTION
Fix compilation on Linux Centos 6 by making sure we compile with -fPIC option and create a libRenderLib.a file so the linker will find it.
Also fixes the Release build (longestAxisLength not found).
